### PR TITLE
Design to Fail

### DIFF
--- a/commercetools.NET/Common/Client.cs
+++ b/commercetools.NET/Common/Client.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System.Threading;
 
 namespace commercetools.Common
 {

--- a/commercetools.NET/Common/Client.cs
+++ b/commercetools.NET/Common/Client.cs
@@ -106,7 +106,7 @@ namespace commercetools.Common
                 }
                 else if (this.Configuration.InternalServerErrorRetryInterval > 0)
                 {
-                    Thread.Sleep(this.Configuration.InternalServerErrorRetryInterval);
+                    await Task.Delay(this.Configuration.InternalServerErrorRetryInterval);
                 }
             }
             return response;
@@ -160,7 +160,7 @@ namespace commercetools.Common
                     }
                     else if (this.Configuration.InternalServerErrorRetryInterval > 0)
                     {
-                        Thread.Sleep(this.Configuration.InternalServerErrorRetryInterval);
+                        await Task.Delay(this.Configuration.InternalServerErrorRetryInterval);
                     }
                 }
             }
@@ -216,7 +216,7 @@ namespace commercetools.Common
                 }
                 else if (this.Configuration.InternalServerErrorRetryInterval > 0)
                 {
-                    Thread.Sleep(this.Configuration.InternalServerErrorRetryInterval);
+                    await Task.Delay(this.Configuration.InternalServerErrorRetryInterval);
                 }
             }
             return response;
@@ -293,7 +293,7 @@ namespace commercetools.Common
                 }
                 else if (this.Configuration.InternalServerErrorRetryInterval > 0)
                 {
-                    Thread.Sleep(this.Configuration.InternalServerErrorRetryInterval);
+                    await Task.Delay(this.Configuration.InternalServerErrorRetryInterval);
                 }
             }
             return response;
@@ -341,7 +341,7 @@ namespace commercetools.Common
                 }
                 else if (this.Configuration.InternalServerErrorRetryInterval > 0)
                 {
-                    Thread.Sleep(this.Configuration.InternalServerErrorRetryInterval);
+                    await Task.Delay(this.Configuration.InternalServerErrorRetryInterval);
                 }
             }
             return response;

--- a/commercetools.NET/Common/Client.cs
+++ b/commercetools.NET/Common/Client.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System.Threading;
 
 namespace commercetools.Common
 {
@@ -82,22 +83,32 @@ namespace commercetools.Common
 
             string url = string.Concat(this.Configuration.ApiUrl, "/", this.Configuration.ProjectKey, endpoint, values.ToQueryString());
 
-            using (HttpClient client = new HttpClient(new ClientLoggingHandler(new HttpClientHandler())))
+            for (int internalServerErrorRetries = -1; internalServerErrorRetries < this.Configuration.InternalServerErrorRetries; internalServerErrorRetries++)
             {
-                client.DefaultRequestHeaders.Accept.Clear();
-                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(this.Token.TokenType, this.Token.AccessToken);
-                client.DefaultRequestHeaders.UserAgent.ParseAdd(this.UserAgent);
-
-                HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, new Uri(url))
+                using (HttpClient client = new HttpClient(new ClientLoggingHandler(new HttpClientHandler())))
                 {
-                    Version = HttpVersion.Version10
-                };
+                    client.DefaultRequestHeaders.Accept.Clear();
+                    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(this.Token.TokenType, this.Token.AccessToken);
+                    client.DefaultRequestHeaders.UserAgent.ParseAdd(this.UserAgent);
 
-                HttpResponseMessage httpResponseMessage = await client.SendAsync(httpRequestMessage);
-                response = await GetResponse<T>(httpResponseMessage);
+                    HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, new Uri(url))
+                    {
+                        Version = HttpVersion.Version10
+                    };
+
+                    HttpResponseMessage httpResponseMessage = await client.SendAsync(httpRequestMessage);
+                    response = await GetResponse<T>(httpResponseMessage);
+                }
+                if (response.StatusCode < 500)
+                {
+                    return response;
+                }
+                else if (this.Configuration.InternalServerErrorRetryInterval > 0)
+                {
+                    Thread.Sleep(this.Configuration.InternalServerErrorRetryInterval);
+                }
             }
-
             return response;
         }
 
@@ -126,24 +137,33 @@ namespace commercetools.Common
             }
 
             string url = string.Concat(this.Configuration.ApiUrl, "/", this.Configuration.ProjectKey, endpoint);
-
-            using (HttpClient client = new HttpClient(new ClientLoggingHandler(new HttpClientHandler())))
+            for (int internalServerErrorRetry = -1; internalServerErrorRetry < this.Configuration.InternalServerErrorRetries; internalServerErrorRetry++)
             {
-                client.DefaultRequestHeaders.Accept.Clear();
-                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(this.Token.TokenType, this.Token.AccessToken);
-                client.DefaultRequestHeaders.UserAgent.ParseAdd(this.UserAgent);
-
-                HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, new Uri(url))
+                using (HttpClient client = new HttpClient(new ClientLoggingHandler(new HttpClientHandler())))
                 {
-                    Version = HttpVersion.Version10,
-                    Content = new StringContent(payload, Encoding.UTF8, "application/json")
-                };
+                    client.DefaultRequestHeaders.Accept.Clear();
+                    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(this.Token.TokenType, this.Token.AccessToken);
+                    client.DefaultRequestHeaders.UserAgent.ParseAdd(this.UserAgent);
 
-                HttpResponseMessage httpResponseMessage = await client.SendAsync(httpRequestMessage);
-                response = await GetResponse<T>(httpResponseMessage);
+                    HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, new Uri(url))
+                    {
+                        Version = HttpVersion.Version10,
+                        Content = new StringContent(payload, Encoding.UTF8, "application/json")
+                    };
+
+                    HttpResponseMessage httpResponseMessage = await client.SendAsync(httpRequestMessage);
+                    response = await GetResponse<T>(httpResponseMessage);
+                    if (response.StatusCode < 500)
+                    {
+                        return response;
+                    }
+                    else if (this.Configuration.InternalServerErrorRetryInterval > 0)
+                    {
+                        Thread.Sleep(this.Configuration.InternalServerErrorRetryInterval);
+                    }
+                }
             }
-
             return response;
         }
 
@@ -173,22 +193,32 @@ namespace commercetools.Common
 
             string url = string.Concat(this.Configuration.ApiUrl, "/", this.Configuration.ProjectKey, endpoint, values.ToQueryString());
 
-            using (HttpClient client = new HttpClient(new ClientLoggingHandler(new HttpClientHandler())))
+            for (int internalServerErrorRetries = -1; internalServerErrorRetries < this.Configuration.InternalServerErrorRetries; internalServerErrorRetries++)
             {
-                client.DefaultRequestHeaders.Accept.Clear();
-                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(this.Token.TokenType, this.Token.AccessToken);
-                client.DefaultRequestHeaders.UserAgent.ParseAdd(this.UserAgent);
-
-                HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, new Uri(url))
+                using (HttpClient client = new HttpClient(new ClientLoggingHandler(new HttpClientHandler())))
                 {
-                    Version = HttpVersion.Version10
-                };
+                    client.DefaultRequestHeaders.Accept.Clear();
+                    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(this.Token.TokenType, this.Token.AccessToken);
+                    client.DefaultRequestHeaders.UserAgent.ParseAdd(this.UserAgent);
 
-                HttpResponseMessage httpResponseMessage = await client.SendAsync(httpRequestMessage);
-                response = await GetResponse<T>(httpResponseMessage);
+                    HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, new Uri(url))
+                    {
+                        Version = HttpVersion.Version10
+                    };
+
+                    HttpResponseMessage httpResponseMessage = await client.SendAsync(httpRequestMessage);
+                    response = await GetResponse<T>(httpResponseMessage);
+                }
+                if (response.StatusCode < 500)
+                {
+                    return response;
+                }
+                else if (this.Configuration.InternalServerErrorRetryInterval > 0)
+                {
+                    Thread.Sleep(this.Configuration.InternalServerErrorRetryInterval);
+                }
             }
-
             return response;
         }
 
@@ -239,23 +269,33 @@ namespace commercetools.Common
 
             string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Concat(this.Configuration.ClientID, ":", this.Configuration.ClientSecret)));
 
-            using (HttpClient client = new HttpClient(new ClientLoggingHandler(new HttpClientHandler())))
+            for (int internalServerErrorRetries = -1; internalServerErrorRetries < this.Configuration.InternalServerErrorRetries; internalServerErrorRetries++)
             {
-                client.DefaultRequestHeaders.Accept.Clear();
-                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
-                client.DefaultRequestHeaders.UserAgent.ParseAdd(this.UserAgent);
-
-                HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, new Uri(this.Configuration.OAuthUrl))
+                using (HttpClient client = new HttpClient(new ClientLoggingHandler(new HttpClientHandler())))
                 {
-                    Version = HttpVersion.Version10,
-                    Content = new FormUrlEncodedContent(pairs)
-                };
+                    client.DefaultRequestHeaders.Accept.Clear();
+                    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+                    client.DefaultRequestHeaders.UserAgent.ParseAdd(this.UserAgent);
 
-                HttpResponseMessage httpResponseMessage = await client.SendAsync(httpRequestMessage);
-                response = await GetResponse<Token>(httpResponseMessage);
+                    HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, new Uri(this.Configuration.OAuthUrl))
+                    {
+                        Version = HttpVersion.Version10,
+                        Content = new FormUrlEncodedContent(pairs)
+                    };
+
+                    HttpResponseMessage httpResponseMessage = await client.SendAsync(httpRequestMessage);
+                    response = await GetResponse<Token>(httpResponseMessage);
+                }
+                if (response.StatusCode < 500)
+                {
+                    return response;
+                }
+                else if (this.Configuration.InternalServerErrorRetryInterval > 0)
+                {
+                    Thread.Sleep(this.Configuration.InternalServerErrorRetryInterval);
+                }
             }
-
             return response;
         }
 
@@ -277,23 +317,33 @@ namespace commercetools.Common
 
             string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Concat(this.Configuration.ClientID, ":", this.Configuration.ClientSecret)));
 
-            using (HttpClient client = new HttpClient(new ClientLoggingHandler(new HttpClientHandler())))
+            for (int internalServerErrorRetries = -1; internalServerErrorRetries < this.Configuration.InternalServerErrorRetries; internalServerErrorRetries++)
             {
-                client.DefaultRequestHeaders.Accept.Clear();
-                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
-                client.DefaultRequestHeaders.UserAgent.ParseAdd(this.UserAgent);
-
-                HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, new Uri(this.Configuration.OAuthUrl))
+                using (HttpClient client = new HttpClient(new ClientLoggingHandler(new HttpClientHandler())))
                 {
-                    Version = HttpVersion.Version10,
-                    Content = new FormUrlEncodedContent(pairs)
-                };
+                    client.DefaultRequestHeaders.Accept.Clear();
+                    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+                    client.DefaultRequestHeaders.UserAgent.ParseAdd(this.UserAgent);
 
-                HttpResponseMessage httpResponseMessage = await client.SendAsync(httpRequestMessage);
-                response = await GetResponse<Token>(httpResponseMessage);
+                    HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, new Uri(this.Configuration.OAuthUrl))
+                    {
+                        Version = HttpVersion.Version10,
+                        Content = new FormUrlEncodedContent(pairs)
+                    };
+
+                    HttpResponseMessage httpResponseMessage = await client.SendAsync(httpRequestMessage);
+                    response = await GetResponse<Token>(httpResponseMessage);
+                }
+                if (response.StatusCode < 500)
+                {
+                    return response;
+                }
+                else if (this.Configuration.InternalServerErrorRetryInterval > 0)
+                {
+                    Thread.Sleep(this.Configuration.InternalServerErrorRetryInterval);
+                }
             }
-
             return response;
         }
 

--- a/commercetools.NET/Common/Configuration.cs
+++ b/commercetools.NET/Common/Configuration.cs
@@ -13,6 +13,8 @@
         public string ClientID { get; private set; }
         public string ClientSecret { get; private set; }
         public ProjectScope Scope { get; private set; }
+        public int InternalServerErrorRetries { get; set; }
+        public int InternalServerErrorRetryInterval { get; set; }
 
         #endregion
 
@@ -27,7 +29,9 @@
         /// <param name="clientID"></param>
         /// <param name="clientSecret"></param>
         /// <param name="scope"></param>
-        public Configuration(string oAuthUrl, string apiUrl, string projectKey, string clientID, string clientSecret, ProjectScope scope)
+        /// <param name="internalServerErrorRetries">Used to specify amount of retries when an internal server error occurs</param>
+        /// <param name="internalServerErrorRetryInterval">Used to specify the amount of time in milliseconds to wait between retries when an internal server error occurs</param>
+        public Configuration(string oAuthUrl, string apiUrl, string projectKey, string clientID, string clientSecret, ProjectScope scope, int internalServerErrorRetries = 1, int internalServerErrorRetryInterval = 100)
         {
             this.OAuthUrl = oAuthUrl;
             this.ApiUrl = apiUrl;
@@ -35,7 +39,8 @@
             this.ClientID = clientID;
             this.ClientSecret = clientSecret;
             this.Scope = scope;
-
+            this.InternalServerErrorRetries = internalServerErrorRetries;
+            this.InternalServerErrorRetryInterval = internalServerErrorRetryInterval;
             if (this.OAuthUrl.EndsWith("/"))
             {
                 this.OAuthUrl = this.OAuthUrl.Remove(this.OAuthUrl.Length - 1);


### PR DESCRIPTION
Added functionality to permit service retries upon receiving a status code 500+.

Usage: Supply optional internalServiceErrorRetries and internalServerErrorRetryInterval parameters during instantiation of Configuration class.

Default values (retry interval based on milliseconds):
internalServiceErrorRetries: 1
internalServiceErrorRetryInterval: 100