### PR TITLE
Support ExternalAmount TaxMode functionality

### DIFF
--- a/commercetools.NET.Tests/Helper.cs
+++ b/commercetools.NET.Tests/Helper.cs
@@ -86,6 +86,34 @@ namespace commercetools.Tests
         }
 
         /// <summary>
+        /// Gets a test cart draft in externalamount tax mode.
+        /// </summary>
+        /// <param name="project">Project</param>
+        /// <param name="customerId">Customer ID</param>
+        /// <returns>CartDraft</returns>
+        public static CartDraft GetTestCartExternalTaxModeDraft(Project.Project project, string customerId = null)
+        {
+            Address shippingAddress = Helper.GetTestAddress(project);
+            Address billingAddress = Helper.GetTestAddress(project);
+
+            string currency = project.Currencies[0];
+            string country = project.Countries[0];
+
+            CartDraft cartDraft = new CartDraft(currency);
+            cartDraft.Country = country;
+            cartDraft.InventoryMode = InventoryMode.None;
+            cartDraft.ShippingAddress = shippingAddress;
+            cartDraft.BillingAddress = billingAddress;
+            cartDraft.DeleteDaysAfterLastModification = GetRandomNumber(1, 10);
+            cartDraft.TaxMode = TaxMode.ExternalAmount;
+            if (!string.IsNullOrWhiteSpace(customerId))
+            {
+                cartDraft.CustomerId = customerId;
+            }
+            return cartDraft;
+        }
+
+        /// <summary>
         /// Gets a test cart draft using external tax mode.
         /// </summary>
         /// <param name="project">Project</param>
@@ -155,7 +183,7 @@ namespace commercetools.Tests
             });
             return cartDraft;
         }
- 
+
         /// <summary>
         /// Gets a test cart draft with custom line items using external tax mode.
         /// </summary>
@@ -195,6 +223,47 @@ namespace commercetools.Tests
                 },
                 Slug = "Test-CustomLineItem-Slug",
                 ExternalTaxRate = new ExternalTaxRateDraft("TestExternalTaxRate", project.Countries[0]) { Amount = 0 }
+            });
+            return cartDraft;
+        }
+        /// <summary>
+        /// Gets a test cart draft with custom line items using externalamount tax mode.
+        /// </summary>
+        /// <param name="project">Project</param>
+        /// <param name="customerId">Customer ID</param>
+        /// <returns>CartDraft</returns>
+        public static CartDraft GetTestCartDraftWithCustomLineItemsUsingExternalAmountTaxMode(Project.Project project, string customerId = null)
+        {
+            var shippingAddress = GetTestAddress(project);
+            var billingAddress = GetTestAddress(project);
+            var name = new LocalizedString();
+            name.Values.Add("en", "Test-CustomLineItem");
+            var currency = project.Currencies[0];
+            var country = project.Countries[0];
+
+            var cartDraft = new CartDraft(currency)
+            {
+                Country = country,
+                InventoryMode = InventoryMode.None,
+                ShippingAddress = shippingAddress,
+                BillingAddress = billingAddress,
+                TaxMode = TaxMode.ExternalAmount,
+                CustomLineItems = new List<CustomLineItemDraft>()
+            };
+
+            if (!string.IsNullOrWhiteSpace(customerId))
+            {
+                cartDraft.CustomerId = customerId;
+            }
+            cartDraft.CustomLineItems.Add(new CustomLineItemDraft(name)
+            {
+                Quantity = 40,
+                Money = new Money
+                {
+                    CentAmount = 30,
+                    CurrencyCode = currency
+                },
+                Slug = "Test-CustomLineItem-Slug",
             });
             return cartDraft;
         }
@@ -414,7 +483,6 @@ namespace commercetools.Tests
                 requiresDiscountCode = isActive.Value ? GetRandomBoolean() : false;
             }
             var cartDiscountDraft = await GetTestCartDiscountDraft(project, client, isActive.Value, requiresCartDiscount.Value, "lineItemCount(1 = 1) > 0", "1=1", 5000, false);
-
             var cartDiscountResponse = await client.CartDiscounts().CreateCartDiscountAsync(cartDiscountDraft);
             var discountCodeDraft = new DiscountCodeDraft(requiresDiscountCode.Value ? GetRandomString(10) : null,
                 new List<Reference>

--- a/commercetools.NET/Carts/Enums.cs
+++ b/commercetools.NET/Carts/Enums.cs
@@ -76,6 +76,7 @@ namespace commercetools.Carts
     {
         Platform,
         External,
+        ExternalAmount,
         Disabled
     }
 }

--- a/commercetools.NET/Carts/ExternalTaxAmountDraft.cs
+++ b/commercetools.NET/Carts/ExternalTaxAmountDraft.cs
@@ -1,0 +1,35 @@
+﻿using Newtonsoft.Json;
+using commercetools.Common;
+
+namespace commercetools.Carts
+{
+    /// <summary>
+    /// ExternalTaxAmountDraft
+    /// </summary>
+    /// <see href="https://dev.commercetools.com/http-api-projects-carts.html#externaltaxamountdraft"/>
+    public class ExternalTaxAmountDraft
+    {
+        #region Properties
+
+        [JsonProperty(PropertyName = "totalGross")]
+        public Money TotalGross { get; set; }
+
+        [JsonProperty(PropertyName = "taxRate")]
+        public ExternalTaxRateDraft TaxRate { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public ExternalTaxAmountDraft(Money totalGross, ExternalTaxRateDraft taxRate)
+        {
+            this.TotalGross = totalGross;
+            this.TaxRate = taxRate;
+        }
+
+        #endregion
+    }
+}

--- a/commercetools.NET/Carts/UpdateActions/SetCartTotalTaxAction.cs
+++ b/commercetools.NET/Carts/UpdateActions/SetCartTotalTaxAction.cs
@@ -1,0 +1,36 @@
+﻿using commercetools.Common;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace commercetools.Carts.UpdateActions
+{
+    /// <summary>
+    /// The total tax amount of the cart can be set if it has the ExternalAmount TaxMode.
+    /// </summary>
+    /// <see href="https://dev.commercetools.com/http-api-projects-carts.html#set-cart-total-tax"/>
+    public class SetCartTotalTaxAction : UpdateAction
+    {
+        #region Properties
+
+        [JsonProperty(PropertyName = "externalTotalGross")]
+        public Money ExternalTotalGross { get; set; }
+
+        [JsonProperty(PropertyName = "externalTaxPortions")]
+        public List<TaxPortion> ExternalTaxPortions { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public SetCartTotalTaxAction(Money externalTotalGross)
+        {
+            this.Action = "setCartTotalTax";
+            this.ExternalTotalGross = externalTotalGross;
+        }
+
+        #endregion
+    }
+}

--- a/commercetools.NET/Carts/UpdateActions/SetCustomLineItemTaxAmountAction.cs
+++ b/commercetools.NET/Carts/UpdateActions/SetCustomLineItemTaxAmountAction.cs
@@ -1,0 +1,42 @@
+﻿using commercetools.Common;
+using Newtonsoft.Json;
+
+namespace commercetools.Carts.UpdateActions
+{
+    /// <summary>
+    /// A custom line item tax amount can be set if the cart has the ExternalAmount TaxMode.
+    /// </summary>
+    /// <see href="https://dev.commercetools.com/http-api-projects-carts.html#set-customlineitem-taxamount"/>
+    public class SetCustomLineItemTaxAmountAction : UpdateAction
+    {
+        #region Properties
+
+        /// <summary>
+        /// CustomLineItemId
+        /// </summary>
+        [JsonProperty(PropertyName = "customLineItemId")]
+        public string CustomLineItemId  { get; set; }
+
+        /// <summary>
+        /// An external tax amount can be set if the cart has the ExternalAmount TaxMode.
+        /// </summary>
+        [JsonProperty(PropertyName = "externalTaxAmount")]
+        public ExternalTaxAmountDraft ExternalTaxAmount { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="customLineItemId">CustomLineItemId</param>
+        public SetCustomLineItemTaxAmountAction(string customLineItemId)
+        {
+            this.Action = "setCustomLineItemTaxAmount";
+            this.CustomLineItemId = customLineItemId;
+        }
+
+        #endregion
+    }
+}

--- a/commercetools.NET/Carts/UpdateActions/SetLineItemTaxAmountAction.cs
+++ b/commercetools.NET/Carts/UpdateActions/SetLineItemTaxAmountAction.cs
@@ -1,0 +1,42 @@
+﻿using commercetools.Common;
+using Newtonsoft.Json;
+
+namespace commercetools.Carts.UpdateActions
+{
+    /// <summary>
+    /// A line item tax amount can be set if the cart has the ExternalAmount TaxMode.
+    /// </summary>
+    /// <see href="https://dev.commercetools.com/http-api-projects-carts.html#set-lineitem-taxamount"/>
+    public class SetLineItemTaxAmountAction : UpdateAction
+    {
+        #region Properties
+
+        /// <summary>
+        /// Id of an existing LineItem.
+        /// </summary>
+        [JsonProperty(PropertyName = "lineItemId")]
+        public string LineItemId { get; set; }
+
+        /// <summary>
+        /// An external tax amount can be set if the cart has the ExternalAmount TaxMode.
+        /// </summary>
+        [JsonProperty(PropertyName = "externalTaxAmount")]
+        public ExternalTaxAmountDraft ExternalTaxAmount { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="lineItemId">Id of an existing Product.</param>
+        public SetLineItemTaxAmountAction(string lineItemId)
+        {
+            this.Action = "setLineItemTaxAmount";
+            this.LineItemId = lineItemId;
+        }
+
+        #endregion
+    }
+}

--- a/commercetools.NET/Carts/UpdateActions/SetShippingMethodTaxAmountAction.cs
+++ b/commercetools.NET/Carts/UpdateActions/SetShippingMethodTaxAmountAction.cs
@@ -1,0 +1,34 @@
+﻿using commercetools.Common;
+using Newtonsoft.Json;
+
+namespace commercetools.Carts.UpdateActions
+{
+    /// <summary>
+    /// A shipping method tax amount can be set if the cart has the ExternalAmount TaxMode.
+    /// </summary>
+    /// <see href="https://dev.commercetools.com/http-api-projects-carts.html#set-shippingmethod-taxamount"/>
+    public class SetShippingMethodTaxAmountAction : UpdateAction
+    {
+        #region Properties
+
+        /// <summary>
+        /// ExternalTaxAmount
+        /// </summary>
+        [JsonProperty(PropertyName = "externalTaxAmount")]
+        public ExternalTaxAmountDraft ExternalTaxAmount { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public SetShippingMethodTaxAmountAction()
+        {
+            this.Action = "setShippingMethodTaxAmount";
+        }
+
+        #endregion
+    }
+}

--- a/commercetools.NET/commercetools.NET.csproj
+++ b/commercetools.NET/commercetools.NET.csproj
@@ -81,6 +81,7 @@
     <Compile Include="CartDiscounts\UpdateActions\SetValidFromAction.cs" />
     <Compile Include="CartDiscounts\UpdateActions\SetValidUntilAction.cs" />
     <Compile Include="Carts\ExternalLineItemTotalPrice.cs" />
+    <Compile Include="Carts\ExternalTaxAmountDraft.cs" />
     <Compile Include="Carts\UpdateActions\AddCustomLineItemAction.cs" />
     <Compile Include="Carts\UpdateActions\AddDiscountCodeAction.cs" />
     <Compile Include="Carts\UpdateActions\AddLineItemAction.cs" />
@@ -116,11 +117,13 @@
     <Compile Include="Carts\UpdateActions\RemoveLineItemAction.cs" />
     <Compile Include="Carts\UpdateActions\RemovePaymentAction.cs" />
     <Compile Include="Carts\UpdateActions\SetBillingAddressAction.cs" />
+    <Compile Include="Carts\UpdateActions\SetCartTotalTaxAction.cs" />
     <Compile Include="Carts\UpdateActions\SetCountryAction.cs" />
     <Compile Include="Carts\UpdateActions\SetCustomerEmailAction.cs" />
     <Compile Include="Carts\UpdateActions\SetCustomerIdAction.cs" />
     <Compile Include="Carts\UpdateActions\SetCustomLineItemCustomFieldAction.cs" />
     <Compile Include="Carts\UpdateActions\SetCustomLineItemCustomTypeAction.cs" />
+    <Compile Include="Carts\UpdateActions\SetCustomLineItemTaxAmountAction.cs" />
     <Compile Include="Carts\UpdateActions\SetCustomLineItemTaxRateAction.cs" />
     <Compile Include="Carts\UpdateActions\SetCustomShippingMethodAction.cs" />
     <Compile Include="Carts\UpdateActions\SetCustomTypeAction.cs" />
@@ -128,11 +131,13 @@
     <Compile Include="Carts\UpdateActions\SetLineItemCustomFieldAction.cs" />
     <Compile Include="Carts\UpdateActions\SetLineItemCustomTypeAction.cs" />
     <Compile Include="Carts\UpdateActions\SetLineItemPriceAction.cs" />
+    <Compile Include="Carts\UpdateActions\SetLineItemTaxAmountAction.cs" />
     <Compile Include="Carts\UpdateActions\SetLineItemTaxRateAction.cs" />
     <Compile Include="Carts\UpdateActions\SetLineItemTotalPriceAction.cs" />
     <Compile Include="Carts\UpdateActions\SetLocaleAction.cs" />
     <Compile Include="Carts\UpdateActions\SetShippingAddressAction.cs" />
     <Compile Include="Carts\UpdateActions\SetShippingMethodAction.cs" />
+    <Compile Include="Carts\UpdateActions\SetShippingMethodTaxAmountAction.cs" />
     <Compile Include="Carts\UpdateActions\SetShippingMethodTaxRateAction.cs" />
     <Compile Include="Categories\CategoryQueryResult.cs" />
     <Compile Include="Categories\Extensions.cs" />


### PR DESCRIPTION
Added functionality to set line item tax amount, custom line item tax amount, shipping method tax amount, and cart total tax. Added unit test to confirm ExternalMode TaxMode base success of functionality: ShouldCreateAndDeleteCartInExternalAmountTaxModeAndTestExternalAmountTaxModeOrientedActions 