### PR TITLE
HttpClient Enhancements

### DIFF
--- a/commercetools.NET/CartDiscounts/CartDiscountManager.cs
+++ b/commercetools.NET/CartDiscounts/CartDiscountManager.cs
@@ -18,7 +18,7 @@ namespace commercetools.CartDiscounts
 
         #region Member Variables
 
-        private readonly Client _client;
+        private readonly IClient _client;
 
         #endregion
 
@@ -28,7 +28,7 @@ namespace commercetools.CartDiscounts
         /// Constructor
         /// </summary>
         /// <param name="client">Client</param>
-        public CartDiscountManager(Client client)
+        public CartDiscountManager(IClient client)
         {
             _client = client;
         }

--- a/commercetools.NET/CartDiscounts/Extensions.cs
+++ b/commercetools.NET/CartDiscounts/Extensions.cs
@@ -8,7 +8,7 @@ namespace commercetools.CartDiscounts
         /// Creates an instance of the CartDiscountManager.
         /// </summary>
         /// <returns>CartDiscountManager</returns>
-        public static CartDiscountManager CartDiscounts(this Client client)
+        public static CartDiscountManager CartDiscounts(this IClient client)
         {
             return new CartDiscountManager(client);
         }

--- a/commercetools.NET/Carts/CartManager.cs
+++ b/commercetools.NET/Carts/CartManager.cs
@@ -25,7 +25,7 @@ namespace commercetools.Carts
 
         #region Member Variables
 
-        private Client _client;
+        private readonly IClient _client;
 
         #endregion
 
@@ -35,7 +35,7 @@ namespace commercetools.Carts
         /// Constructor
         /// </summary>
         /// <param name="client">Client</param>
-        public CartManager(Client client)
+        public CartManager(IClient client)
         {
             _client = client;
         }

--- a/commercetools.NET/Carts/Extensions.cs
+++ b/commercetools.NET/Carts/Extensions.cs
@@ -11,7 +11,7 @@ namespace commercetools.Carts
         /// Creates an instance of the CartManager.
         /// </summary>
         /// <returns>CartManager</returns>
-        public static CartManager Carts(this Client client)
+        public static CartManager Carts(this IClient client)
         {
             return new CartManager(client);
         }

--- a/commercetools.NET/Categories/CategoryManager.cs
+++ b/commercetools.NET/Categories/CategoryManager.cs
@@ -24,7 +24,7 @@ namespace commercetools.Categories
 
         #region Member Variables
 
-        private Client _client;
+        private readonly IClient _client;
 
         #endregion 
 
@@ -34,7 +34,7 @@ namespace commercetools.Categories
         /// Constructor
         /// </summary>
         /// <param name="client">Client</param>
-        public CategoryManager(Client client)
+        public CategoryManager(IClient client)
         {
             _client = client;
         }

--- a/commercetools.NET/Categories/Extensions.cs
+++ b/commercetools.NET/Categories/Extensions.cs
@@ -11,7 +11,7 @@ namespace commercetools.Categories
         /// Creates an instance of the CategoryManager.
         /// </summary>
         /// <returns>CategoryManager</returns>
-        public static CategoryManager Categories(this Client client)
+        public static CategoryManager Categories(this IClient client)
         {
             return new CategoryManager(client);
         }

--- a/commercetools.NET/Common/Client.cs
+++ b/commercetools.NET/Common/Client.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System.Threading;
 
 namespace commercetools.Common
 {
@@ -35,6 +36,33 @@ namespace commercetools.Common
         /// </summary>
         public string UserAgent { get; private set; }
 
+        /// <summary>
+        /// The HttpClient to utilize in all API requests. If null, HttpClientPool instances are utilized
+        /// </summary>
+        public HttpClient HttpClientInstance { get; set; }
+
+        private static LimitedPool<HttpClient> _HttpClientPool = null;
+        private static object httpClientPoolLock = new object();
+        /// <summary>
+        /// Application scope HttpClientPool to utilize for all API requests when HttpClientInstance of Client instance is null
+        /// </summary>
+        private static LimitedPool<HttpClient> HttpClientPool
+        {
+            get {
+                if (_HttpClientPool == null)
+                {
+                    lock (httpClientPoolLock)
+                    {
+                        if (_HttpClientPool == null)
+                        {
+                            _HttpClientPool = new LimitedPool<HttpClient>(() => { return new HttpClient(new ClientLoggingHandler(new HttpClientHandler())); }, client => client.Dispose());
+                        }
+                    }
+                }
+                return _HttpClientPool;
+            }
+        }
+
         #endregion
 
         #region Constructors
@@ -42,10 +70,10 @@ namespace commercetools.Common
         /// <summary>
         /// Constructor
         /// </summary>
-        public Client(Configuration configuration)
+        public Client(Configuration configuration, HttpClient httpClientInstance = null)
         {
             this.Configuration = configuration;
-
+            this.HttpClientInstance = httpClientInstance;
             Assembly assembly = Assembly.GetExecutingAssembly();
             string assemblyVersion = assembly.GetName().Version.ToString();
             string dotNetVersion = Environment.Version.ToString();
@@ -82,32 +110,35 @@ namespace commercetools.Common
 
             string url = string.Concat(this.Configuration.ApiUrl, "/", this.Configuration.ProjectKey, endpoint, values.ToQueryString());
 
-            for (int internalServerErrorRetries = -1; internalServerErrorRetries < this.Configuration.InternalServerErrorRetries; internalServerErrorRetries++)
+            using (LimitedPoolItem<HttpClient> poolItem = HttpClientInstance != null ? null : HttpClientPool.Get(this.Configuration.HttpClientPoolItemLifetime))
             {
-                using (HttpClient client = new HttpClient(new ClientLoggingHandler(new HttpClientHandler())))
+                HttpClient client = HttpClientInstance ?? poolItem.Value;
+                client.DefaultRequestHeaders.Accept.Clear();
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(this.Token.TokenType, this.Token.AccessToken);
+                client.DefaultRequestHeaders.UserAgent.Clear();
+                client.DefaultRequestHeaders.UserAgent.ParseAdd(this.UserAgent);
+
+                HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, new Uri(url))
                 {
-                    client.DefaultRequestHeaders.Accept.Clear();
-                    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(this.Token.TokenType, this.Token.AccessToken);
-                    client.DefaultRequestHeaders.UserAgent.ParseAdd(this.UserAgent);
+                    Version = HttpVersion.Version10
+                };
 
-                    HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, new Uri(url))
-                    {
-                        Version = HttpVersion.Version10
-                    };
-
+                for (int internalServerErrorRetries = -1; internalServerErrorRetries < this.Configuration.InternalServerErrorRetries; internalServerErrorRetries++)
+                {
                     HttpResponseMessage httpResponseMessage = await client.SendAsync(httpRequestMessage);
                     response = await GetResponse<T>(httpResponseMessage);
-                }
-                if (response.StatusCode < 500)
-                {
-                    return response;
-                }
-                else if (this.Configuration.InternalServerErrorRetryInterval > 0)
-                {
-                    await Task.Delay(this.Configuration.InternalServerErrorRetryInterval);
+                    if (response.StatusCode < 500)
+                    {
+                        return response;
+                    }
+                    else if (this.Configuration.InternalServerErrorRetryInterval > 0)
+                    {
+                        await Task.Delay(this.Configuration.InternalServerErrorRetryInterval);
+                    }
                 }
             }
+
             return response;
         }
 
@@ -136,21 +167,22 @@ namespace commercetools.Common
             }
 
             string url = string.Concat(this.Configuration.ApiUrl, "/", this.Configuration.ProjectKey, endpoint);
-            for (int internalServerErrorRetry = -1; internalServerErrorRetry < this.Configuration.InternalServerErrorRetries; internalServerErrorRetry++)
+            using (LimitedPoolItem<HttpClient> poolItem = HttpClientInstance != null ? null : HttpClientPool.Get(this.Configuration.HttpClientPoolItemLifetime))
             {
-                using (HttpClient client = new HttpClient(new ClientLoggingHandler(new HttpClientHandler())))
+                HttpClient client = HttpClientInstance ?? poolItem.Value;
+                client.DefaultRequestHeaders.Accept.Clear();
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(this.Token.TokenType, this.Token.AccessToken);
+                client.DefaultRequestHeaders.UserAgent.Clear();
+                client.DefaultRequestHeaders.UserAgent.ParseAdd(this.UserAgent);
+
+                HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, new Uri(url))
                 {
-                    client.DefaultRequestHeaders.Accept.Clear();
-                    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(this.Token.TokenType, this.Token.AccessToken);
-                    client.DefaultRequestHeaders.UserAgent.ParseAdd(this.UserAgent);
-
-                    HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, new Uri(url))
-                    {
-                        Version = HttpVersion.Version10,
-                        Content = new StringContent(payload, Encoding.UTF8, "application/json")
-                    };
-
+                    Version = HttpVersion.Version10,
+                    Content = new StringContent(payload, Encoding.UTF8, "application/json")
+                };
+                for (int internalServerErrorRetry = -1; internalServerErrorRetry < this.Configuration.InternalServerErrorRetries; internalServerErrorRetry++)
+                {
                     HttpResponseMessage httpResponseMessage = await client.SendAsync(httpRequestMessage);
                     response = await GetResponse<T>(httpResponseMessage);
                     if (response.StatusCode < 500)
@@ -192,30 +224,32 @@ namespace commercetools.Common
 
             string url = string.Concat(this.Configuration.ApiUrl, "/", this.Configuration.ProjectKey, endpoint, values.ToQueryString());
 
-            for (int internalServerErrorRetries = -1; internalServerErrorRetries < this.Configuration.InternalServerErrorRetries; internalServerErrorRetries++)
+            using (LimitedPoolItem<HttpClient> poolItem = HttpClientInstance != null ? null : HttpClientPool.Get(this.Configuration.HttpClientPoolItemLifetime))
             {
-                using (HttpClient client = new HttpClient(new ClientLoggingHandler(new HttpClientHandler())))
+                HttpClient client = HttpClientInstance ?? poolItem.Value;
+                client.DefaultRequestHeaders.Accept.Clear();
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(this.Token.TokenType, this.Token.AccessToken);
+                client.DefaultRequestHeaders.UserAgent.Clear();
+                client.DefaultRequestHeaders.UserAgent.ParseAdd(this.UserAgent);
+
+                HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, new Uri(url))
                 {
-                    client.DefaultRequestHeaders.Accept.Clear();
-                    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(this.Token.TokenType, this.Token.AccessToken);
-                    client.DefaultRequestHeaders.UserAgent.ParseAdd(this.UserAgent);
+                    Version = HttpVersion.Version10
+                };
 
-                    HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, new Uri(url))
-                    {
-                        Version = HttpVersion.Version10
-                    };
-
+                for (int internalServerErrorRetries = -1; internalServerErrorRetries < this.Configuration.InternalServerErrorRetries; internalServerErrorRetries++)
+                {
                     HttpResponseMessage httpResponseMessage = await client.SendAsync(httpRequestMessage);
                     response = await GetResponse<T>(httpResponseMessage);
-                }
-                if (response.StatusCode < 500)
-                {
-                    return response;
-                }
-                else if (this.Configuration.InternalServerErrorRetryInterval > 0)
-                {
-                    await Task.Delay(this.Configuration.InternalServerErrorRetryInterval);
+                    if (response.StatusCode < 500)
+                    {
+                        return response;
+                    }
+                    else if (this.Configuration.InternalServerErrorRetryInterval > 0)
+                    {
+                        await Task.Delay(this.Configuration.InternalServerErrorRetryInterval);
+                    }
                 }
             }
             return response;
@@ -244,10 +278,10 @@ namespace commercetools.Common
              * The refresh token flow is currently only available for the password flow, which is currently not supported by the SDK.
              * More info: https://dev.commercetools.com/http-api-authorization.html#password-flow
              * 
-            else if (this.Token.IsExpired())
-            {
-                this.Token = RefreshTokenAsync(this.Token.RefreshToken);
-            }
+                else if (this.Token.IsExpired())
+                {
+                    this.Token = RefreshTokenAsync(this.Token.RefreshToken);
+                }
              */
         }
 
@@ -267,32 +301,33 @@ namespace commercetools.Common
             };
 
             string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Concat(this.Configuration.ClientID, ":", this.Configuration.ClientSecret)));
-
-            for (int internalServerErrorRetries = -1; internalServerErrorRetries < this.Configuration.InternalServerErrorRetries; internalServerErrorRetries++)
+            using (LimitedPoolItem<HttpClient> poolItem = HttpClientInstance != null ? null : HttpClientPool.Get(this.Configuration.HttpClientPoolItemLifetime))
             {
-                using (HttpClient client = new HttpClient(new ClientLoggingHandler(new HttpClientHandler())))
+                HttpClient client = HttpClientInstance ?? poolItem.Value;
+                client.DefaultRequestHeaders.Accept.Clear();
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+                client.DefaultRequestHeaders.UserAgent.Clear();
+                client.DefaultRequestHeaders.UserAgent.ParseAdd(this.UserAgent);
+
+                HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, new Uri(this.Configuration.OAuthUrl))
                 {
-                    client.DefaultRequestHeaders.Accept.Clear();
-                    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
-                    client.DefaultRequestHeaders.UserAgent.ParseAdd(this.UserAgent);
+                    Version = HttpVersion.Version10,
+                    Content = new FormUrlEncodedContent(pairs)
+                };
 
-                    HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, new Uri(this.Configuration.OAuthUrl))
-                    {
-                        Version = HttpVersion.Version10,
-                        Content = new FormUrlEncodedContent(pairs)
-                    };
-
+                for (int internalServerErrorRetries = -1; internalServerErrorRetries < this.Configuration.InternalServerErrorRetries; internalServerErrorRetries++)
+                {
                     HttpResponseMessage httpResponseMessage = await client.SendAsync(httpRequestMessage);
                     response = await GetResponse<Token>(httpResponseMessage);
-                }
-                if (response.StatusCode < 500)
-                {
-                    return response;
-                }
-                else if (this.Configuration.InternalServerErrorRetryInterval > 0)
-                {
-                    await Task.Delay(this.Configuration.InternalServerErrorRetryInterval);
+                    if (response.StatusCode < 500)
+                    {
+                        return response;
+                    }
+                    else if (this.Configuration.InternalServerErrorRetryInterval > 0)
+                    {
+                        await Task.Delay(this.Configuration.InternalServerErrorRetryInterval);
+                    }
                 }
             }
             return response;
@@ -315,32 +350,33 @@ namespace commercetools.Common
             };
 
             string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Concat(this.Configuration.ClientID, ":", this.Configuration.ClientSecret)));
-
-            for (int internalServerErrorRetries = -1; internalServerErrorRetries < this.Configuration.InternalServerErrorRetries; internalServerErrorRetries++)
+            using (LimitedPoolItem<HttpClient> poolItem = HttpClientInstance != null ? null : HttpClientPool.Get(this.Configuration.HttpClientPoolItemLifetime))
             {
-                using (HttpClient client = new HttpClient(new ClientLoggingHandler(new HttpClientHandler())))
+                HttpClient client = HttpClientInstance ?? poolItem.Value;
+                client.DefaultRequestHeaders.Accept.Clear();
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+                client.DefaultRequestHeaders.UserAgent.Clear();
+                client.DefaultRequestHeaders.UserAgent.ParseAdd(this.UserAgent);
+
+                HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, new Uri(this.Configuration.OAuthUrl))
                 {
-                    client.DefaultRequestHeaders.Accept.Clear();
-                    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
-                    client.DefaultRequestHeaders.UserAgent.ParseAdd(this.UserAgent);
+                    Version = HttpVersion.Version10,
+                    Content = new FormUrlEncodedContent(pairs)
+                };
 
-                    HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, new Uri(this.Configuration.OAuthUrl))
-                    {
-                        Version = HttpVersion.Version10,
-                        Content = new FormUrlEncodedContent(pairs)
-                    };
-
+                for (int internalServerErrorRetries = -1; internalServerErrorRetries < this.Configuration.InternalServerErrorRetries; internalServerErrorRetries++)
+                {
                     HttpResponseMessage httpResponseMessage = await client.SendAsync(httpRequestMessage);
                     response = await GetResponse<Token>(httpResponseMessage);
-                }
-                if (response.StatusCode < 500)
-                {
-                    return response;
-                }
-                else if (this.Configuration.InternalServerErrorRetryInterval > 0)
-                {
-                    await Task.Delay(this.Configuration.InternalServerErrorRetryInterval);
+                    if (response.StatusCode < 500)
+                    {
+                        return response;
+                    }
+                    else if (this.Configuration.InternalServerErrorRetryInterval > 0)
+                    {
+                        await Task.Delay(this.Configuration.InternalServerErrorRetryInterval);
+                    }
                 }
             }
             return response;
@@ -367,7 +403,6 @@ namespace commercetools.Common
             if (response.StatusCode >= 200 && response.StatusCode < 300)
             {
                 response.Success = true;
-
                 if (resultType == typeof(JObject) || resultType == typeof(JArray) || resultType.IsArray || (resultType.IsGenericType && resultType.Name.Equals(typeof(List<>).Name)))
                 {
                     response.Result = JsonConvert.DeserializeObject<T>(await httpResponseMessage.Content.ReadAsStringAsync());

--- a/commercetools.NET/Common/Client.cs
+++ b/commercetools.NET/Common/Client.cs
@@ -17,7 +17,7 @@ namespace commercetools.Common
     /// <summary>
     /// A client for executing requests against the commercetools web service.
     /// </summary>
-    public class Client
+    public class Client : IClient
     {
         #region Properties
 

--- a/commercetools.NET/Common/Configuration.cs
+++ b/commercetools.NET/Common/Configuration.cs
@@ -1,4 +1,6 @@
-﻿namespace commercetools.Common
+﻿using System;
+
+namespace commercetools.Common
 {
     /// <summary>
     /// A set of configuration variables needed for making requests with the client.
@@ -15,7 +17,7 @@
         public ProjectScope Scope { get; private set; }
         public int InternalServerErrorRetries { get; set; }
         public int InternalServerErrorRetryInterval { get; set; }
-
+        public TimeSpan HttpClientPoolItemLifetime { get; set; }
         #endregion
 
         #region Constructors
@@ -31,7 +33,8 @@
         /// <param name="scope"></param>
         /// <param name="internalServerErrorRetries">Used to specify amount of retries when an internal server error occurs</param>
         /// <param name="internalServerErrorRetryInterval">Used to specify the amount of time in milliseconds to wait between retries when an internal server error occurs</param>
-        public Configuration(string oAuthUrl, string apiUrl, string projectKey, string clientID, string clientSecret, ProjectScope scope, int internalServerErrorRetries = 1, int internalServerErrorRetryInterval = 100)
+        /// <param name="httpClientPoolItemLifetime">Used to specify the timespan to wait before disposing an HttpClient LimitedPoolItem</param>
+        public Configuration(string oAuthUrl, string apiUrl, string projectKey, string clientID, string clientSecret, ProjectScope scope, int internalServerErrorRetries = 1, int internalServerErrorRetryInterval = 100, TimeSpan? httpClientPoolItemLifetime = null)
         {
             this.OAuthUrl = oAuthUrl;
             this.ApiUrl = apiUrl;
@@ -41,6 +44,8 @@
             this.Scope = scope;
             this.InternalServerErrorRetries = internalServerErrorRetries;
             this.InternalServerErrorRetryInterval = internalServerErrorRetryInterval;
+            this.HttpClientPoolItemLifetime = httpClientPoolItemLifetime ?? TimeSpan.FromHours(1);
+
             if (this.OAuthUrl.EndsWith("/"))
             {
                 this.OAuthUrl = this.OAuthUrl.Remove(this.OAuthUrl.Length - 1);

--- a/commercetools.NET/Common/IClient.cs
+++ b/commercetools.NET/Common/IClient.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Specialized;
+using System.Threading.Tasks;
+
+namespace commercetools.Common
+{
+    public interface IClient
+    {
+        /// <summary>
+        /// Configuration
+        /// </summary>
+        Configuration Configuration { get; }
+
+        /// <summary>
+        /// Token
+        /// </summary>
+        Token Token { get; }
+
+        /// <summary>
+        /// The identifiying user agent that is included in all API requests.
+        /// </summary>
+        string UserAgent { get; }
+
+        /// <summary>
+        /// Executes a GET request.
+        /// </summary>
+        /// <param name="endpoint">API endpoint, excluding the project key</param>
+        /// <param name="values">Values</param>
+        /// <returns>JSON object</returns>
+        Task<Response<T>> GetAsync<T>(string endpoint, NameValueCollection values = null);
+
+        /// <summary>
+        /// Executes a POST request.
+        /// </summary>
+        /// <param name="endpoint"></param>
+        /// <param name="payload">Body of the request</param>
+        /// <returns>JSON object</returns>
+        Task<Response<T>> PostAsync<T>(string endpoint, string payload);
+
+        /// <summary>
+        /// Executes a DELETE request.
+        /// </summary>
+        /// <param name="endpoint">API endpoint, excluding the project key</param>
+        /// <param name="values">Values</param>
+        /// <returns>JSON object</returns>
+        Task<Response<T>> DeleteAsync<T>(string endpoint, NameValueCollection values = null);
+
+        /// <summary>
+        /// Retrieves a token from the authorization API using the client credentials flow.
+        /// </summary>
+        /// <returns>Token</returns>
+        /// <see href="http://dev.commercetools.com/http-api-authorization.html#authorization-flows"/>
+        Task<Response<Token>> GetTokenAsync();
+
+        /// <summary>
+        /// Refreshes a token from the authorization API using the refresh token flow.
+        /// </summary>
+        /// <param name="refreshToken">Refresh token value from the current token</param>
+        /// <returns>Token</returns>
+        /// <see href="http://dev.commercetools.com/http-api-authorization.html#authorization-flows"/>
+        Task<Response<Token>> RefreshTokenAsync(string refreshToken);
+    }
+}

--- a/commercetools.NET/Common/LimitedPool.cs
+++ b/commercetools.NET/Common/LimitedPool.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading;
+
+namespace commercetools.Common
+{
+    public class LimitedPool<T> : IDisposable where T : class
+    {
+        readonly Func<T> _valueFactory;
+        readonly Action<T> _valueDisposeAction;
+        readonly ConcurrentStack<LimitedPoolItem<T>> _pool;
+        bool _disposed;
+        public LimitedPool(Func<T> valueFactory, Action<T> valueDisposeAction)
+        {
+            _valueFactory = valueFactory;
+            _valueDisposeAction = valueDisposeAction;
+            _pool = new ConcurrentStack<LimitedPoolItem<T>>();
+        }
+        public int IdleCount => _pool.Count;
+        public LimitedPoolItem<T> Get(TimeSpan limitedPoolItemLifeSpan)
+        {
+            LimitedPoolItem<T> item;
+            // try to get live cached item
+            while (!_disposed && _pool.TryPop(out item))
+            {
+                if (!item.Expired && item.Lifetime == limitedPoolItemLifeSpan) {
+                    return item;
+                }
+                if (item.Expired)
+                {
+                    // dispose expired item
+                    item.Dispose();
+                    // try to collect other items as well
+                    CollectAllExpiredItems();
+                }
+            }
+            // since no cached items available we create a new one
+            return new LimitedPoolItem<T>(_valueFactory(), disposedItem =>
+            {
+                if (_disposed || disposedItem.Expired)
+                {
+                    // item has been expired, dispose it
+                    if (Interlocked.CompareExchange(ref disposedItem.DisposeFlag, 1, 0) == 0)
+                    {
+                        _valueDisposeAction(disposedItem.Value);
+                    }
+                }
+                else
+                {
+                    // item is still fresh enough, return it to the pool
+                    if (!_disposed)
+                    {
+                        _pool.Push(disposedItem);
+                    }
+                }
+            }, limitedPoolItemLifeSpan);
+        }
+        void CollectAllExpiredItems()
+        {
+            const int maximumBufferSize = 1000;
+            int length = Math.Min(_pool.Count, maximumBufferSize);
+            if (length <= 0) {
+                return;
+            }
+
+            LimitedPoolItem<T>[] items = new LimitedPoolItem<T>[length];
+            int poppedItems = _pool.TryPopRange(items);
+            for (int i = 0; i < poppedItems; i++)
+            {
+                LimitedPoolItem<T> item = items[i];
+                // if item is expired it will be disposed, otherwise returned back to the pool
+                try
+                {
+                    item.Dispose();
+                }
+                catch
+                {
+                    // return rest items back to the pool and rethrow
+                    int nextIndex = i + 1;
+                    if (nextIndex < poppedItems) {
+                        _pool.PushRange(items, nextIndex, poppedItems - nextIndex);
+                    }
+                    throw;
+                }
+            }
+        }
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _disposed = true;
+                LimitedPoolItem<T>[] items = _pool.ToArray();
+                foreach (LimitedPoolItem<T> item in items)
+                {
+                    _valueDisposeAction(item.Value);
+                }
+            }
+        }
+    }
+}

--- a/commercetools.NET/Common/LimitedPoolItem.cs
+++ b/commercetools.NET/Common/LimitedPoolItem.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace commercetools.Common
+{
+    public class LimitedPoolItem<T> : IDisposable
+    {
+        readonly Action<LimitedPoolItem<T>> _disposeAction;
+        readonly TimeSpan _lifetime;
+        bool _expired;
+        internal int DisposeFlag;
+        public T Value { get; }
+        internal bool Expired
+        {
+            get
+            {
+                if (_expired)
+                {
+                    return true;
+                }
+                _expired = _stopwatch.Elapsed > _lifetime;
+                return _expired;
+            }
+        }
+        internal TimeSpan Lifetime
+        {
+            get
+            {
+                return _lifetime;
+            }
+        }
+        readonly Stopwatch _stopwatch;
+        internal LimitedPoolItem(T value, Action<LimitedPoolItem<T>> disposeAction, TimeSpan lifetime)
+        {
+            _disposeAction = disposeAction;
+            _lifetime = lifetime;
+            Value = value;
+            _stopwatch = Stopwatch.StartNew();
+        }
+        public void Expire()
+        {
+            _expired = true;
+        }
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+        void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _disposeAction(this);
+            }
+        }
+    }
+}

--- a/commercetools.NET/Customers/CustomerManager.cs
+++ b/commercetools.NET/Customers/CustomerManager.cs
@@ -25,7 +25,7 @@ namespace commercetools.Customers
 
         #region Member Variables
 
-        private Client _client;
+        private readonly IClient _client;
 
         #endregion
 
@@ -35,7 +35,7 @@ namespace commercetools.Customers
         /// Constructor
         /// </summary>
         /// <param name="client">Client</param>
-        public CustomerManager(Client client)
+        public CustomerManager(IClient client)
         {
             _client = client;
         }

--- a/commercetools.NET/Customers/Extensions.cs
+++ b/commercetools.NET/Customers/Extensions.cs
@@ -11,7 +11,7 @@ namespace commercetools.Customers
         /// Creates an instance of the CustomerManager.
         /// </summary>
         /// <returns>CustomerManager</returns>
-        public static CustomerManager Customers(this Client client)
+        public static CustomerManager Customers(this IClient client)
         {
             return new CustomerManager(client);
         }

--- a/commercetools.NET/DiscountCodes/DiscountCodeManager.cs
+++ b/commercetools.NET/DiscountCodes/DiscountCodeManager.cs
@@ -18,7 +18,7 @@ namespace commercetools.DiscountCodes
 
         #region Member Variables
 
-        private readonly Client _client;
+        private readonly IClient _client;
 
         #endregion
 
@@ -28,7 +28,7 @@ namespace commercetools.DiscountCodes
         /// Constructor
         /// </summary>
         /// <param name="client">Client</param>
-        public DiscountCodeManager(Client client)
+        public DiscountCodeManager(IClient client)
         {
             _client = client;
         }

--- a/commercetools.NET/DiscountCodes/Extensions.cs
+++ b/commercetools.NET/DiscountCodes/Extensions.cs
@@ -9,7 +9,7 @@ namespace commercetools.DiscountCodes
         /// Creates an instance of the CartDiscountManager.
         /// </summary>
         /// <returns>CartDiscountManager</returns>
-        public static DiscountCodeManager DiscountCodes(this Client client)
+        public static DiscountCodeManager DiscountCodes(this IClient client)
         {
             return new DiscountCodeManager(client);
         }

--- a/commercetools.NET/Messages/Extensions.cs
+++ b/commercetools.NET/Messages/Extensions.cs
@@ -11,7 +11,7 @@ namespace commercetools.Messages
         /// Creates an instance of the MessageManager.
         /// </summary>
         /// <returns>MessageManager</returns>
-        public static MessageManager Messages(this Client client)
+        public static MessageManager Messages(this IClient client)
         {
             return new MessageManager(client);
         }

--- a/commercetools.NET/Messages/MessageManager.cs
+++ b/commercetools.NET/Messages/MessageManager.cs
@@ -19,7 +19,7 @@ namespace commercetools.Messages
 
         #region Member Variables
 
-        private Client _client;
+        private readonly IClient _client;
 
         #endregion
 
@@ -29,7 +29,7 @@ namespace commercetools.Messages
         /// Constructor
         /// </summary>
         /// <param name="client">Client</param>
-        public MessageManager(Client client)
+        public MessageManager(IClient client)
         {
             _client = client;
         }

--- a/commercetools.NET/Orders/Extensions.cs
+++ b/commercetools.NET/Orders/Extensions.cs
@@ -11,7 +11,7 @@ namespace commercetools.Orders
         /// Creates an instance of the OrderManager.
         /// </summary>
         /// <returns>OrderManager</returns>
-        public static OrderManager Orders(this Client client)
+        public static OrderManager Orders(this IClient client)
         {
             return new OrderManager(client);
         }

--- a/commercetools.NET/Orders/OrderManager.cs
+++ b/commercetools.NET/Orders/OrderManager.cs
@@ -24,7 +24,7 @@ namespace commercetools.Orders
 
         #region Member Variables
 
-        private Client _client;
+        private readonly IClient _client;
 
         #endregion
 
@@ -34,7 +34,7 @@ namespace commercetools.Orders
         /// Constructor
         /// </summary>
         /// <param name="client">Client</param>
-        public OrderManager(Client client)
+        public OrderManager(IClient client)
         {
             _client = client;
         }

--- a/commercetools.NET/Payments/Extensions.cs
+++ b/commercetools.NET/Payments/Extensions.cs
@@ -11,7 +11,7 @@ namespace commercetools.Payments
         /// Creates an instance of the PaymentManager.
         /// </summary>
         /// <returns>PaymentManager</returns>
-        public static PaymentManager Payments(this Client client)
+        public static PaymentManager Payments(this IClient client)
         {
             return new PaymentManager(client);
         }

--- a/commercetools.NET/Payments/PaymentManager.cs
+++ b/commercetools.NET/Payments/PaymentManager.cs
@@ -24,7 +24,7 @@ namespace commercetools.Payments
 
         #region Member Variables
 
-        private Client _client;
+        private readonly IClient _client;
 
         #endregion
 
@@ -34,7 +34,7 @@ namespace commercetools.Payments
         /// Constructor
         /// </summary>
         /// <param name="client">Client</param>
-        public PaymentManager(Client client)
+        public PaymentManager(IClient client)
         {
             _client = client;
         }

--- a/commercetools.NET/ProductProjectionSearch/Extensions.cs
+++ b/commercetools.NET/ProductProjectionSearch/Extensions.cs
@@ -11,7 +11,7 @@ namespace commercetools.ProductProjectionSearch
         /// Creates an instance of the ProductProjectionSearchManager.
         /// </summary>
         /// <returns>ProductProjectionSearchManager</returns>
-        public static ProductProjectionSearchManager ProductProjectionSearch(this Client client)
+        public static ProductProjectionSearchManager ProductProjectionSearch(this IClient client)
         {
             return new ProductProjectionSearchManager(client);
         }

--- a/commercetools.NET/ProductProjectionSearch/ProductProjectionSearchManager.cs
+++ b/commercetools.NET/ProductProjectionSearch/ProductProjectionSearchManager.cs
@@ -20,7 +20,7 @@ namespace commercetools.ProductProjectionSearch
 
         #region Member Variables
 
-        private Client _client;
+        private readonly IClient _client;
 
         #endregion 
 
@@ -30,7 +30,7 @@ namespace commercetools.ProductProjectionSearch
         /// Constructor
         /// </summary>
         /// <param name="client">Client</param>
-        public ProductProjectionSearchManager(Client client)
+        public ProductProjectionSearchManager(IClient client)
         {
             _client = client;
         }

--- a/commercetools.NET/ProductProjections/Extensions.cs
+++ b/commercetools.NET/ProductProjections/Extensions.cs
@@ -11,7 +11,7 @@ namespace commercetools.ProductProjections
         /// Creates an instance of the ProductProjectionManager.
         /// </summary>
         /// <returns>ProductProjectionManager</returns>
-        public static ProductProjectionManager ProductProjections(this Client client)
+        public static ProductProjectionManager ProductProjections(this IClient client)
         {
             return new ProductProjectionManager(client);
         }

--- a/commercetools.NET/ProductProjections/ProductProjectionManager.cs
+++ b/commercetools.NET/ProductProjections/ProductProjectionManager.cs
@@ -20,7 +20,7 @@ namespace commercetools.ProductProjections
 
         #region Member Variables
 
-        private Client _client;
+        private readonly IClient _client;
 
         #endregion 
 
@@ -30,7 +30,7 @@ namespace commercetools.ProductProjections
         /// Constructor
         /// </summary>
         /// <param name="client">Client</param>
-        public ProductProjectionManager(Client client)
+        public ProductProjectionManager(IClient client)
         {
             _client = client;
         }

--- a/commercetools.NET/ProductTypes/Extensions.cs
+++ b/commercetools.NET/ProductTypes/Extensions.cs
@@ -11,7 +11,7 @@ namespace commercetools.ProductTypes
         /// Creates an instance of the ProductTypeManager.
         /// </summary>
         /// <returns>ProductTypeManager</returns>
-        public static ProductTypeManager ProductTypes(this Client client)
+        public static ProductTypeManager ProductTypes(this IClient client)
         {
             return new ProductTypeManager(client);
         }

--- a/commercetools.NET/ProductTypes/ProductTypeManager.cs
+++ b/commercetools.NET/ProductTypes/ProductTypeManager.cs
@@ -24,7 +24,7 @@ namespace commercetools.ProductTypes
 
         #region Member Variables
 
-        private Client _client;
+        private readonly IClient _client;
 
         #endregion 
 
@@ -34,7 +34,7 @@ namespace commercetools.ProductTypes
         /// Constructor
         /// </summary>
         /// <param name="client">Client</param>
-        public ProductTypeManager(Client client)
+        public ProductTypeManager(IClient client)
         {
             _client = client;
         }

--- a/commercetools.NET/Products/Extensions.cs
+++ b/commercetools.NET/Products/Extensions.cs
@@ -11,7 +11,7 @@ namespace commercetools.Products
         /// Creates an instance of the ProductManager.
         /// </summary>
         /// <returns>ProductManager</returns>
-        public static ProductManager Products(this Client client)
+        public static ProductManager Products(this IClient client)
         {
             return new ProductManager(client);
         }

--- a/commercetools.NET/Products/ProductManager.cs
+++ b/commercetools.NET/Products/ProductManager.cs
@@ -24,7 +24,7 @@ namespace commercetools.Products
 
         #region Member Variables
 
-        private Client _client;
+        private readonly IClient _client;
 
         #endregion 
 
@@ -34,7 +34,7 @@ namespace commercetools.Products
         /// Constructor
         /// </summary>
         /// <param name="client">Client</param>
-        public ProductManager(Client client)
+        public ProductManager(IClient client)
         {
             _client = client;
         }

--- a/commercetools.NET/Project/Extensions.cs
+++ b/commercetools.NET/Project/Extensions.cs
@@ -11,7 +11,7 @@ namespace commercetools.Project
         /// Creates an instance of the ProjectManager.
         /// </summary>
         /// <returns>ProjectManager</returns>
-        public static ProjectManager Project(this Client client)
+        public static ProjectManager Project(this IClient client)
         {
             return new ProjectManager(client);
         }

--- a/commercetools.NET/Project/ProjectManager.cs
+++ b/commercetools.NET/Project/ProjectManager.cs
@@ -12,7 +12,7 @@ namespace commercetools.Project
     {
         #region Member Variables
 
-        private Client _client;
+        private readonly IClient _client;
 
         #endregion 
 
@@ -22,7 +22,7 @@ namespace commercetools.Project
         /// Constructor.
         /// </summary>
         /// <param name="client">Client</param>
-        public ProjectManager(Client client)
+        public ProjectManager(IClient client)
         {
             _client = client;
         }

--- a/commercetools.NET/ShippingMethods/Extensions.cs
+++ b/commercetools.NET/ShippingMethods/Extensions.cs
@@ -11,7 +11,7 @@ namespace commercetools.ShippingMethods
         /// Creates an instance of the ShippingMethodManager.
         /// </summary>
         /// <returns>ShippingMethodManager</returns>
-        public static ShippingMethodManager ShippingMethods(this Client client)
+        public static ShippingMethodManager ShippingMethods(this IClient client)
         {
             return new ShippingMethodManager(client);
         }

--- a/commercetools.NET/ShippingMethods/ShippingMethodManager.cs
+++ b/commercetools.NET/ShippingMethods/ShippingMethodManager.cs
@@ -24,7 +24,7 @@ namespace commercetools.ShippingMethods
 
         #region Member Variables
 
-        private Client _client;
+        private readonly IClient _client;
 
         #endregion
 
@@ -34,7 +34,7 @@ namespace commercetools.ShippingMethods
         /// Constructor
         /// </summary>
         /// <param name="client">Client</param>
-        public ShippingMethodManager(Client client)
+        public ShippingMethodManager(IClient client)
         {
             _client = client;
         }

--- a/commercetools.NET/Subscriptions/Extensions.cs
+++ b/commercetools.NET/Subscriptions/Extensions.cs
@@ -11,7 +11,7 @@ namespace commercetools.Subscriptions
         /// Creates an instance of the SubscriptionManager.
         /// </summary>
         /// <returns>SubscriptionManager</returns>
-        public static SubscriptionManager Subscriptions(this Client client)
+        public static SubscriptionManager Subscriptions(this IClient client)
         {
             return new SubscriptionManager(client);
         }

--- a/commercetools.NET/Subscriptions/SubscriptionManager.cs
+++ b/commercetools.NET/Subscriptions/SubscriptionManager.cs
@@ -24,7 +24,7 @@ namespace commercetools.Subscriptions
 
         #region Member Variables
 
-        private Client _client;
+        private readonly IClient _client;
 
         #endregion 
 
@@ -34,7 +34,7 @@ namespace commercetools.Subscriptions
         /// Constructor
         /// </summary>
         /// <param name="client">Client</param>
-        public SubscriptionManager(Client client)
+        public SubscriptionManager(IClient client)
         {
             _client = client;
         }

--- a/commercetools.NET/TaxCategories/Extensions.cs
+++ b/commercetools.NET/TaxCategories/Extensions.cs
@@ -11,7 +11,7 @@ namespace commercetools.TaxCategories
         /// Creates an instance of the TaxCategoryManager.
         /// </summary>
         /// <returns>TaxCategoryManager</returns>
-        public static TaxCategoryManager TaxCategories(this Client client)
+        public static TaxCategoryManager TaxCategories(this IClient client)
         {
             return new TaxCategoryManager(client);
         }

--- a/commercetools.NET/TaxCategories/TaxCategoryManager.cs
+++ b/commercetools.NET/TaxCategories/TaxCategoryManager.cs
@@ -24,7 +24,7 @@ namespace commercetools.TaxCategories
 
         #region Member Variables
 
-        private Client _client;
+        private readonly IClient _client;
 
         #endregion
 
@@ -34,7 +34,7 @@ namespace commercetools.TaxCategories
         /// Constructor
         /// </summary>
         /// <param name="client">Client</param>
-        public TaxCategoryManager(Client client)
+        public TaxCategoryManager(IClient client)
         {
             _client = client;
         }

--- a/commercetools.NET/Types/Extensions.cs
+++ b/commercetools.NET/Types/Extensions.cs
@@ -11,7 +11,7 @@ namespace commercetools.Types
         /// Creates an instance of the TypeManager.
         /// </summary>
         /// <returns>TypeManager</returns>
-        public static TypeManager Types(this Client client)
+        public static TypeManager Types(this IClient client)
         {
             return new TypeManager(client);
         }

--- a/commercetools.NET/Types/TypeManager.cs
+++ b/commercetools.NET/Types/TypeManager.cs
@@ -24,7 +24,7 @@ namespace commercetools.Types
 
         #region Member Variables
 
-        private Client _client;
+        private readonly IClient _client;
 
         #endregion
 
@@ -34,7 +34,7 @@ namespace commercetools.Types
         /// Constructor
         /// </summary>
         /// <param name="client">Client</param>
-        public TypeManager(Client client)
+        public TypeManager(IClient client)
         {
             _client = client;
         }

--- a/commercetools.NET/Zones/Extensions.cs
+++ b/commercetools.NET/Zones/Extensions.cs
@@ -11,7 +11,7 @@ namespace commercetools.Zones
         /// Creates an instance of the ZoneManager.
         /// </summary>
         /// <returns>ZoneManager</returns>
-        public static ZoneManager Zones(this Client client)
+        public static ZoneManager Zones(this IClient client)
         {
             return new ZoneManager(client);
         }

--- a/commercetools.NET/Zones/ZoneManager.cs
+++ b/commercetools.NET/Zones/ZoneManager.cs
@@ -24,7 +24,7 @@ namespace commercetools.Zones
 
         #region Member Variables
 
-        private Client _client;
+        private readonly IClient _client;
 
         #endregion
 
@@ -34,7 +34,7 @@ namespace commercetools.Zones
         /// Constructor
         /// </summary>
         /// <param name="client">Client</param>
-        public ZoneManager(Client client)
+        public ZoneManager(IClient client)
         {
             _client = client;
         }


### PR DESCRIPTION
The 2 enhancements below have been developed to address the concerns raised with the HttpClient being created/disposed on every request, and requests for the ability to have access to the HttpClient itself from the consuming application. (detailed in #57 and #58).

1. Addressing the HttpClient being created/disposed on every request:
The HttpClient is not a thread-safe in entirety and there are other considerations that were required to ensure that the issue addressed all concerns. Utilizing the HttpClient as a singleton throughout the application can introduce issues in high load environments such as deadlocks, potential memory leaks, and potentially affect fail-over and load balancing scenarios where underlying socket sessions will prevent host switching.

To overcome this, we added a new LimitedPool and LimitedPoolItem class and refactored them to suit the requirements of SDK. These refactored classes do not use the HttpClient as a singleton which ensures thead-safe and deadlocks are not hit, and are configurable to specify the lifetime of the cached HttpClient objects which avoids potential fail-over and load balancing issues.

To specify a specific lifetime of the cached HttpClient objects, you either supply the optional constructor parameter httpClientPoolItemLifetime to the Configuration class, or you set it directly in the Configuration class through the HttpClientPoolItemLifetime property.

When the Configuration class HttpClientPoolItemLifetime property has not been specifically set via the constructor or direct property access, the HttpClientPoolItem and its associated HttpClient will have a lifetime of 1 hour.

2. Providing the ability to have access to the HttpClient itself from the consuming application via a constructor and/or public property. NOTE: When utilizing it this way, you will in effect bypass the pooling entirely and must supply the HttpClient that is to be used.
Using this method of HttpClient consumption, you supply the Client class with the HttpClient to be utilized – whether it be during instantiation through the optional httpClientInstance constructor parameter, or afterwards through the HttpClientInstance property accessor.

Overall Refactoring Specifics:
- Added optional httpClientPoolItemLifetime parameter to constructor of Configuration class. If unspecified, will utilize a default value of 1 hour.
- Added public get/set HttpClientPoolItemLifetime property to Configuration class.
- Added optional httpClientInstance parameter to constructor of Client class.
- Added public get/set HttpClientInstance property to Client class.
- Added private static get access to new HttpClientPool property with instantiation lock.
- Added and refactored LimitedPool and LimitedPoolItem class for SDK specific usage with IDisposable objects and varied configuration lifetimes.
- Refactored all HttpClient accesses in Client to utilize the HttpClientInstance if not null, otherwise it will draw an instance from the HttpClientPool.