### PR TITLE
New NUnit.ConsoleRunner to fix broken AppVeyor builds

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-#tool nuget:https://www.myget.org/F/nunit/api/v3/index.json?package=NUnit.ConsoleRunner&version=3.9.0-dev-03938
+#tool nuget:https://www.myget.org/F/nunit/api/v3/index.json?package=NUnit.ConsoleRunner&version=3.10.0-dev-04086
 
 //////////////////////////////////////////////////////////////////////
 // ARGUMENTS


### PR DESCRIPTION
I noticed that my pull requests builds are failing due to a missing package no longer on myget (see current versions here: https://www.myget.org/feed/nunit/package/nuget/NUnit.ConsoleRunner)

Fingers crossed the new version builds now.