### PR TITLE
Added missing members to DiscountCodeState

### DIFF
--- a/commercetools.NET/Carts/Enums.cs
+++ b/commercetools.NET/Carts/Enums.cs
@@ -20,9 +20,11 @@ namespace commercetools.Carts
     public enum DiscountCodeState
     {
         NotActive,
+        NotValid,
         DoesNotMatchCart,
         MatchesCart,
-        MaxApplicationReached
+        MaxApplicationReached,
+        ApplicationStoppedByPreviousDiscount
     }
 
     /// <summary>


### PR DESCRIPTION
Added missing members based on: [issue 83](https://github.com/commercetools/commercetools-dotnet-sdk/issues/83).

I checked useages and the enum is not used as integer value anywhere so I added the members in the order of the documentation page.