### PR TITLE
Support for dynamic types in SetAttributeAction

### DIFF
--- a/commercetools.NET/Products/UpdateActions/SetAttributeAction.cs
+++ b/commercetools.NET/Products/UpdateActions/SetAttributeAction.cs
@@ -37,7 +37,7 @@ namespace commercetools.Products.UpdateActions
         /// Value
         /// </summary>
         [JsonProperty(PropertyName = "value")]
-        public dynamic Value { get; set; }
+        public object Value { get; set; }
 
         /// <summary>
         /// Staged

--- a/commercetools.NET/Products/UpdateActions/SetAttributeAction.cs
+++ b/commercetools.NET/Products/UpdateActions/SetAttributeAction.cs
@@ -37,7 +37,7 @@ namespace commercetools.Products.UpdateActions
         /// Value
         /// </summary>
         [JsonProperty(PropertyName = "value")]
-        public FieldType Value { get; set; }
+        public dynamic Value { get; set; }
 
         /// <summary>
         /// Staged


### PR DESCRIPTION
This is a suggestion to fix a simple but unfortunate error.

We used to use the php implementation of the commercetools-sdk and are currently reworking our codebase to use c#.

When translating methods and structures from php over to c#, we noticed that we can't set an array (List in c#) to `Value` when creating a new `SetAttributeAction`.

We are using the `Value` field to set a `List<LocalizedString>` to it. Unfortunately this is not allowed since Value is a `FieldType`.

As per documentation (https://docs.commercetools.com/http-api-projects-products.html#set-attribute) the `Value` field does not seem to have a fixed type.

I had a look at your php implementation and it does not have a typed value there aswell: https://github.com/commercetools/commercetools-php-sdk/blob/master/src/Core/Request/Products/Command/ProductSetAttributeAction.php