### PR TITLE
Updated log4net to 2.0.8

### DIFF
--- a/commercetools.NET.nuspec
+++ b/commercetools.NET.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright Falcon-Software Company Inc. 2018</copyright>
     <tags>commercetools</tags>
     <dependencies>
-      <dependency id="log4net" version="2.0.5" />
+      <dependency id="log4net" version="2.0.8" />
       <dependency id="Newtonsoft.Json" version="9.0.1" />
     </dependencies>
   </metadata>

--- a/commercetools.NET/packages.config
+++ b/commercetools.NET/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.5" targetFramework="net45" />
+  <package id="log4net" version="2.0.8" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Currently the nuspec file will load the log4net dependency with version 2.0.5. .NET Standard support began in version 2.0.6 (http://logging.apache.org/log4net/release/release-notes.html). This leads to warnings when using the commercetools SDK inside a .NET Core application.

`warning NU1701: Package 'log4net 2.0.5' was restored using '.NETFramework,Version=v4.6.1' instead of the project target framework '.NETCoreApp,Version=v2.2'. This package may not be fully compatible with your project.`

The .csproj file already references to the latest version 2.0.8, but someone missed the nuspec file and the packages.config file. So here is an update for that.