### PR TITLE
Remove private access modifier from CustomerDraft.Salutation

### DIFF
--- a/commercetools.NET/Customers/CustomerDraft.cs
+++ b/commercetools.NET/Customers/CustomerDraft.cs
@@ -160,7 +160,7 @@ namespace commercetools.Customers
         /// The salutation of the customer.
         /// </summary>
         [JsonProperty(PropertyName = "salutation")]
-        public string Salutation { get; private set; }
+        public string Salutation { get; set; }
 
         #endregion
 


### PR DESCRIPTION
I have removed the private access modifier from CustomerDraft.Salutation as this still made it impossible to set the field when creating a new Customer.