### PR TITLE
Add DetailedErrorMessage to ErrorMessage

### DIFF
--- a/commercetools.NET/Common/Client.cs
+++ b/commercetools.NET/Common/Client.cs
@@ -331,7 +331,8 @@ namespace commercetools.Common
                         {
                             string code = error.Value<string>("code");
                             string message = error.Value<string>("message");
-                            response.Errors.Add(new ErrorMessage(code, message));
+                            string detailedErrorMessage = error.Value<string>("detailedErrorMessage");
+                            response.Errors.Add(new ErrorMessage(code, message, detailedErrorMessage));
                         }
                     }
                 }

--- a/commercetools.NET/Common/ErrorMessage.cs
+++ b/commercetools.NET/Common/ErrorMessage.cs
@@ -21,6 +21,12 @@ namespace commercetools.Common
         [JsonProperty(PropertyName = "message")]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Detailed error message
+        /// </summary>
+        [JsonProperty(PropertyName = "detailedErrorMessage")]
+        public string DetailedErrorMessage { get; set; }
+
         #endregion
 
         #region Construtors
@@ -39,6 +45,16 @@ namespace commercetools.Common
         {
             this.Code = code;
             this.Message = message;
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public ErrorMessage(string code, string message, string detailedErrorMessage)
+        {
+            this.Code = code;
+            this.Message = message;
+            this.DetailedErrorMessage = detailedErrorMessage;
         }
 
         #endregion


### PR DESCRIPTION
API responses that fail typically has a lot better error info in the `detailedErrorMessage` property than in the `message` property, but the `detailedErrorMessage` wasn't set on the `ErrorMessage` class.