### PR TITLE
Fix invalid SetCustomTypeAction constructor

### DIFF
--- a/commercetools.NET/Categories/UpdateActions/SetCustomTypeAction.cs
+++ b/commercetools.NET/Categories/UpdateActions/SetCustomTypeAction.cs
@@ -1,4 +1,5 @@
-﻿using commercetools.Common;
+﻿using System;
+using commercetools.Common;
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -35,7 +36,17 @@ namespace commercetools.Categories.UpdateActions
         /// <summary>
         /// Constructor.
         /// </summary>
+        [Obsolete("This constructor is incorrect and will be removed, use the other overload instead")]
         public SetCustomTypeAction(LocalizedString name)
+            : this()
+        {
+
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public SetCustomTypeAction()
         {
             this.Action = "setCustomType";
         }


### PR DESCRIPTION
Takes a `LocalizedString` but doesn't use it, most likely a copy-paste issue. I added an overload instead of removing the constructor to avoid a breaking change.