### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/commercetools.NET.Tests/commercetools.NET.Tests.csproj
+++ b/commercetools.NET.Tests/commercetools.NET.Tests.csproj
@@ -19,14 +19,14 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
         <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
         <PackageReference Include="FluentAssertions" Version="4.19.4" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.4" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.4" />
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.2.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-        <PackageReference Include="NUnit" Version="3.11.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-        <PackageReference Include="System.Text.Json" Version="4.6.0" />
+        <PackageReference Include="NUnit" Version="3.13.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+        <PackageReference Include="System.Text.Json" Version="4.7.1" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Hi@MicheleRezk, I found an issue in the commercetools.NET.Tests.csproj:

Packages Microsoft.Extensions.Configuration.Binder v2.2.0, Microsoft.Extensions.Configuration.EnvironmentVariables v2.2.0, NUnit v3.11.0, NUnit3TestAdapter v3.13.0, Microsoft.NET.Test.Sdk v16.0.1 and System.Text.Json v4.6.0 transitively introduce 97 dependencies into commercetools-dotnet-sdk’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/commercetools-dotnet-sdk.html)), while Microsoft.Extensions.Configuration.Binder v2.2.4, Microsoft.Extensions.Configuration.EnvironmentVariables v2.2.4, NUnit v3.13.2, NUnit3TestAdapter v4.0.0, Microsoft.NET.Test.Sdk v16.1.1 and System.Text.Json v4.7.1 can only introduce 60 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/commercetools-dotnet-sdk_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose