### PR TITLE
chore(docs): update naming to match new branding initiative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # commercetools-dotnet-sdk
 
-:warning: **This commercetools .NET SDK is deprecated effective `1st September 2021.`, We recommend to use our [.NET Core SDK V2](https://docs.commercetools.com/sdk/dotnet-sdk#net-core-sdk-v2).
+:warning: **This Composable Commerce .NET SDK is deprecated effective `1st September 2021.`, We recommend to use our [.NET Core SDK V2](https://docs.commercetools.com/sdk/dotnet-sdk#net-core-sdk-v2).
 
 [![Travis Build Status](https://travis-ci.org/commercetools/commercetools-dotnet-sdk.svg?branch=master)](https://travis-ci.org/commercetools/commercetools-dotnet-sdk)
 [![AppVeyor Build Status](https://img.shields.io/appveyor/ci/commercetools/commercetools-dotnet-sdk.svg)](https://ci.appveyor.com/project/commercetools/commercetools-dotnet-sdk)
 [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.NET.SDK?includePreReleases=true)](https://www.nuget.org/packages/commercetools.NET.SDK)
 
-The commercetools.NET SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.
+The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.
 
 For more documentation please see [the wiki](//github.com/commercetools/commercetools-dotnet-sdk/wiki/commercetools-.NET-SDK-documentation)
 
@@ -16,13 +16,13 @@ For more documentation please see [the wiki](//github.com/commercetools/commerce
 
 ## Using the SDK
 
-You will need a commercetools project to use the SDK.
-If you don't already have one, you can [create a free trial project](http://dev.commercetools.com/getting-started.html) on the commercetools platform and configure the API credentials.
+You will need a Composable Commerce Project to use the SDK.
+If you don't already have one, you can [create a free trial project](http://dev.commercetools.com/getting-started.html) on Composable Commerce and configure the API credentials.
 
 The namespaces in the SDK mirror the sections of the [commercetools HTTP API](http://dev.commercetools.com/http-api.html).
 Access to these namespaces is provided by a fluent interface on the Client class.
 
-Responses from the client are wrapped in a Reponse object so you can determine if the request was successful and view the error(s) returned from the API if it was not.
+Responses from the client are wrapped in a Response object so you can determine if the request was successful and view the error(s) returned from the API if it was not.
 
 ```cs
 
@@ -124,7 +124,7 @@ To contribute changes or improvements, please fork the repository into your acco
     > For Example: In the commercetools.CartDiscounts.CartDiscountDraft class, description, target, isActive, validFrom and validUntil should not be used as constructor parameters as they are not required.
 
 * Wherever applicable, try to treat objects as groups of entities and use a factory to create these groups of entities when response is being parsed.
-    > For Example: The CartDiscountValue entities (AbsoluteCartDiscountValue/RelativeCartDiscountValue/GiftLineItemCartDiscountValue) are treated as a group of entities that share a common type property, Type (Relative/Absolute/GiftLineItem). These entities are created by a CartDiscountValueFactory when we parse the response from the CommerceTools API.
+    > For Example: The CartDiscountValue entities (AbsoluteCartDiscountValue/RelativeCartDiscountValue/GiftLineItemCartDiscountValue) are treated as a group of entities that share a common type property, Type (Relative/Absolute/GiftLineItem). These entities are created by a CartDiscountValueFactory when we parse the response from the Composable Commerce API.
 
 
 ### Mac Users

--- a/commercetools.NET.Examples/CategoryExamples.cs
+++ b/commercetools.NET.Examples/CategoryExamples.cs
@@ -83,10 +83,10 @@ namespace commercetools.Examples
 
             /*  UPDATE A CATEGORY
              *  ===================================================================================
-             *  Each change is made using its own update action object which maps to an update 
+             *  Each change is made using its own update action object which maps to an update
              *  action call in the API. The list of update action objects are sent to the API using
-             *  a single request. If there is an update action in the API that has not yet been 
-             *  implemented in the SDK, you can use the GenericAction class to make any request you 
+             *  a single request. If there is an update action in the API that has not yet been
+             *  implemented in the SDK, you can use the GenericAction class to make any request you
              *  want (as long as it is a valid update action supported by the API).
              */
             categoryName[language] = "Updated Category";
@@ -94,7 +94,7 @@ namespace commercetools.Examples
 
             // Here is how you would make the setDescription request using a GenericAction object.
             LocalizedString categoryDescription = new LocalizedString();
-            categoryDescription[language] = "This is a new category created by the commercetools.NET SDK.";
+            categoryDescription[language] = "This is a new category created by the Composable Commerce .NET SDK.";
 
             GenericAction setDescriptionAction = new GenericAction("setDescription");
             setDescriptionAction["description"] = categoryDescription;
@@ -117,7 +117,7 @@ namespace commercetools.Examples
 
             /*  DELETE A CATEGORY
              *  ===================================================================================
-             *  Delete API requests return a generic response, but some return the object that was 
+             *  Delete API requests return a generic response, but some return the object that was
              *  deleted. The Categories delete request returns the full representation.
              */
             categoryResponse = await client.Categories().DeleteCategoryAsync(category);

--- a/commercetools.NET.Examples/ProductExamples.cs
+++ b/commercetools.NET.Examples/ProductExamples.cs
@@ -60,9 +60,9 @@ namespace commercetools.Examples
 
             /*  CREATE PRODUCT
              *  ===================================================================================
-             *  You will need to specify the type of product you are creating using a 
-             *  resource identifier that references an existing product type in your commercetools 
-             *  project. So before creating the product, we will retrieve a ProductType from the
+             *  You will need to specify the type of product you are creating using a
+             *  resource identifier that references an existing product type in your Project.
+             *  So before creating the product, we will retrieve a ProductType from the
              *  API and use it to create a ResourceIdentifier object.
              */
             Response<ProductTypeQueryResult> productTypeResponse = await client.ProductTypes().QueryProductTypesAsync();
@@ -107,10 +107,10 @@ namespace commercetools.Examples
 
             /*  UPDATE A PRODUCT
              *  ===================================================================================
-             *  Each change is made using its own update action object which maps to an update 
+             *  Each change is made using its own update action object which maps to an update
              *  action call in the API. The list of update action objects are sent to the API using
-             *  a single request. If there is an update action in the API that has not yet been 
-             *  implemented in the SDK, you can use the GenericAction class to make any request you 
+             *  a single request. If there is an update action in the API that has not yet been
+             *  implemented in the SDK, you can use the GenericAction class to make any request you
              *  want (as long as it is a valid update action supported by the API).
              */
             SetKeyAction setKeyAction = new SetKeyAction();
@@ -141,7 +141,7 @@ namespace commercetools.Examples
 
             /*  DELETE A PRODUCT
              *  ===================================================================================
-             *  Delete API requests return a generic response, but some return the object that was 
+             *  Delete API requests return a generic response, but some return the object that was
              *  deleted. The Products delete request returns the full representation.
              */
             productResponse = await client.Products().DeleteProductAsync(product);

--- a/commercetools.NET.Examples/Program.cs
+++ b/commercetools.NET.Examples/Program.cs
@@ -10,12 +10,11 @@ using Configuration = commercetools.Common.Configuration;
 namespace commercetools.Examples
 {
     /// <summary>
-    /// These examples are meant to run against a commercetools project that contains some data;
+    /// These examples are meant to run against a Project that contains some data;
     /// at minimum, the sample data that is included by default when creating a new project should
-    /// be present so that there are at least one currency, language, and product type to work 
+    /// be present so that there are at least one currency, language, and product type to work
     /// with, along with a few products and categories.  All of these examples should successfully
-    /// run against the sample data set that is included when you create a new commercetools 
-    /// project.
+    /// run against the sample data set that is included when you create a new Project.
     /// </summary>
     public class Program
     {
@@ -46,8 +45,8 @@ namespace commercetools.Examples
                 Environment.ExpandEnvironmentVariables(ConfigurationManager.AppSettings["commercetools.ClientID"]),
                 Environment.ExpandEnvironmentVariables(ConfigurationManager.AppSettings["commercetools.ClientSecret"]),
                 ProjectScope.ManageProject);
-            
-            Client client = new Client(configuration);            
+
+            Client client = new Client(configuration);
 
 
             /*  GET PROJECT
@@ -72,9 +71,9 @@ namespace commercetools.Examples
             await CategoryExamples.Run(client, project);
             await OrderExamples.Run(client, project);
             await ProductExamples.Run(client, project);
-                        
 
-           
+
+
         }
     }
 }

--- a/commercetools.NET.Tests/commercetools.NET.Tests.csproj
+++ b/commercetools.NET.Tests/commercetools.NET.Tests.csproj
@@ -6,7 +6,7 @@
         <IsPackable>false</IsPackable>
         <AssemblyName>commercetools.NET.SDK.Tests</AssemblyName>
         <Authors>commercetools</Authors>
-        <Description>The commercetools.NET SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.</Description>
+        <Description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</Description>
         <Copyright>Copyright (c) 2019 Falcon-Software, commercetools and contributors</Copyright>
         <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-sdk</PackageProjectUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/commercetools.NET/Common/Client.cs
+++ b/commercetools.NET/Common/Client.cs
@@ -15,7 +15,7 @@ using System.Threading;
 namespace commercetools.Common
 {
     /// <summary>
-    /// A client for executing requests against the commercetools web service.
+    /// A client for executing requests against the Composable Commerce web service.
     /// </summary>
     public class Client : IClient
     {

--- a/commercetools.NET/Common/Reference.cs
+++ b/commercetools.NET/Common/Reference.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json.Converters;
 namespace commercetools.Common
 {
     /// <summary>
-    /// A JSON object representing a (loose) reference to another resource on the commercetools platform.
+    /// A JSON object representing a (loose) reference to another resource on Composable Commerce
     /// </summary>
     /// <see href="http://dev.commercetools.com/http-api-types.html#reference"/>
     public class Reference

--- a/commercetools.NET/Common/Token.cs
+++ b/commercetools.NET/Common/Token.cs
@@ -27,7 +27,7 @@ namespace commercetools.Common
 
         [JsonProperty(PropertyName = "token_type")]
         public string TokenType { get; private set; }
-        
+
         #endregion
 
         #region Constructors
@@ -51,7 +51,7 @@ namespace commercetools.Common
 
             if (expiresIn.HasValue)
             {
-                // Offset slightly as per commercetools recommendation
+                // Offset slightly as per Composable Commerce recommendation
                 this.ExpiryDate = DateTime.UtcNow.AddSeconds(expiresIn.Value - 60);
             }
 
@@ -60,7 +60,7 @@ namespace commercetools.Common
                 string description = scope.Split(':')[0];
 
                 ProjectScope? projectScope;
-                this.ProjectScope = Helper.TryGetEnumByEnumMemberAttribute<ProjectScope?>(description, out projectScope) ? projectScope : null; 
+                this.ProjectScope = Helper.TryGetEnumByEnumMemberAttribute<ProjectScope?>(description, out projectScope) ? projectScope : null;
             }
         }
 
@@ -81,6 +81,6 @@ namespace commercetools.Common
             return true;
         }
 
-        #endregion 
+        #endregion
     }
 }

--- a/commercetools.NET/CustomObjects/CustomObject.cs
+++ b/commercetools.NET/CustomObjects/CustomObject.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json.Linq;
 namespace commercetools.CustomObjects
 {
     /// <summary>
-    /// Custom objects are a way to store arbitrary JSON-formatted data on the commercetools platform.
+    /// Custom objects are a way to store arbitrary JSON-formatted data on Composable Commerce.
     /// <see href="https://docs.commercetools.com/http-api-projects-custom-objects.html#customobject"/>
     /// </summary>
     public class CustomObject<T>

--- a/commercetools.NET/Payments/Payment.cs
+++ b/commercetools.NET/Payments/Payment.cs
@@ -11,7 +11,7 @@ namespace commercetools.Payments
     /// Payments hold information about the current state of receiving and/or refunding money.
     /// </summary>
     /// <remarks>
-    /// A payment represents one or a logically connected series of financial transactions like reserving money, charging money or refunding money. They serve as a representation of the current state of the payment and can also be used to trigger new transactions. The actual financial process is not done by the commercetools™ platform but usually by a PSP (Payment Service Provider), which is connected via PSP-specific integration implementation. The Payment representation does not contain payment method-specific fields. These are added as CustomFields via a payment method-specific payment type.
+    /// A payment represents one or a logically connected series of financial transactions like reserving money, charging money or refunding money. They serve as a representation of the current state of the payment and can also be used to trigger new transactions. The actual financial process is not done by Composable Commerce but usually by a PSP (Payment Service Provider), which is connected via PSP-specific integration implementation. The Payment representation does not contain payment method-specific fields. These are added as CustomFields via a payment method-specific payment type.
     /// </remarks>
     /// <see href="http://dev.commercetools.com/http-api-projects-payments.html#payment"/>
     public class Payment

--- a/commercetools.NET/commercetools.NET.csproj
+++ b/commercetools.NET/commercetools.NET.csproj
@@ -6,7 +6,7 @@
     <LangVersion>7</LangVersion>
     <Version>1.0.0.0</Version>
     <Authors>commercetools</Authors>
-    <Description>The commercetools.NET SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.</Description>
+    <Description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</Description>
     <Copyright>Copyright (c) 2019 Falcon-Software, commercetools and contributors</Copyright>
     <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-sdk</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
# Description
This PR follows the rebranding initiative by the Marketing and Docs team to change commercetools to Composable Commerce.

https://github.com/commercetools/clients-team-internal/issues/87

NB: This PR does not update the tests, as this is out of scope.